### PR TITLE
Update sept_10_invitees.md

### DIFF
--- a/sept_10_invitees.md
+++ b/sept_10_invitees.md
@@ -2,12 +2,15 @@
 ## Government
 * OSTP (D.J., Jake, E.J., Ryan, Xavier)
 * Commerce (Ian Kalin <IKalin@doc.gov>)
+* Office of Personnel Management (OPM) 
 
 ## Industry
 * LinkedIn (Alan Blue <ablue@linkedin.com>, Pablo Chavez <pchavez@linkedin.com>)
 * Glassdoor (Dawn Lyon <dawn@glassdoor.com>, Robert <robert@glassdoor.com>)
 * Workday (Leighanne Levensaler <leighanne.levensaler@workday.com>, Nathaniel Hundt <natehundt@gmail.com>)
 * Burning Glass (Matt Sigelman <msigelman@burning-glass.com>, Dan Restuccia drestuccia@burning-glass.com)
+* Craigslist - craig@craigslist.org
+* DirectEmployers/National Labor Exchange (Pam Gerassimides
 
 ## Tech
 * Google (Vicki Tardif <vtardif@google.com>)
@@ -16,17 +19,16 @@
 ## Research
 * BLS (Groshen.Erica@bls.gov)
 * University of Chicago (Matthew Gee <matt@theimpactlab.co>)
+* U.S. Census Bureau (Avi Bender <Avi.Bender@census.gov>)
+* Bayes Impact (Eric Liu <eric@bayesimpact.org>)
+* GovLab - Beth Novek <noveck@gmail.com>)
 
 ## O*NET
 * O*NET (Pam Frugoli <Frugoli.Pam@dol.gov>)
+* O*NET (Kim Vitelli <vitelli.kimberly@dol.gov>)
+* O*NET (Byron Zuidema <Zuidema.Byron@dol.gov>)
 
 --------
 
 # Other Partners
-* Bayes Impact (Eric Liu)
-* Aneesh
-* 18F (Gray Brooks, Erie Meyer)
-* USAJobs
-* Indeed
 * 100,000 Jobs Mission (Rachel Book - Bloomberg)
-* DirectEmployers


### PR DESCRIPTION
Please see this version - added representation for the hourly segment (majority of workers in US vs. salary), reorganized some sections, added new contacts and emails and removed people that I think should not be there at this point - but should be during Round 2.
